### PR TITLE
Bug fix for negative looping

### DIFF
--- a/lib/timer_count_down.dart
+++ b/lib/timer_count_down.dart
@@ -124,7 +124,7 @@ class _CountdownState extends State<Countdown> {
       _timer = Timer.periodic(
         widget.interval,
         (Timer timer) {
-          if (_currentMicroSeconds == 0) {
+          if (_currentMicroSeconds <= 0) {
             timer.cancel();
 
             if (widget.onFinished != null) {


### PR DESCRIPTION
```
    if (_currentMicroSeconds != 0) {
      _timer = Timer.periodic(
        widget.interval,
        (Timer timer) {
          if (_currentMicroSeconds == 0) {
            timer.cancel();
```

The `==` on the second last line ([Line 127](https://github.com/DizoftTeam/simple_count_down/blob/fb9070291b5dde0049994bd39d24af7b9a400735/lib/timer_count_down.dart#L127)) needs to be changed to `<=` , otherwise I see the `_currentMicroSeconds` going negative making the countdown endless.

https://user-images.githubusercontent.com/64755088/115080585-9efbbd00-9f20-11eb-9d2f-24edadf68516.mov
